### PR TITLE
Improve wind turbine charts and nodes

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/TimeseriesOutputPanel.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/TimeseriesOutputPanel.tsx
@@ -4,10 +4,12 @@ import { useEffect, useMemo, useState } from "react";
 import { MetricChart, type MetricDataPoint } from "@/features/metrics/MetricChart";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { highlightJson } from "@/lib/jsonUtils";
+import { useMetricHistory } from "@/hooks/useMetricHistory";
 import "@/lib/hljs-theme.css";
 
-const MAX_DATA_POINTS = 6;
-const POLL_INTERVAL_MS = 5000;
+const MAX_DATA_POINTS = 60;
+const POLL_INTERVAL_MS = 1000;
+const MAX_WINDOW_MS = 60_000;
 
 interface IngestionRecord {
   timestamp: number;
@@ -27,10 +29,18 @@ interface TimeseriesData {
   analytics: AnalyticsRecord[];
 }
 
+interface TimestampedAnalytics {
+  timestamp: number;
+  inference_time_ms: number;
+  end_to_end_time_ms: number;
+}
+
 const TimeseriesOutputPanel = () => {
   const [data, setData] = useState<TimeseriesData>({ ingestion: [], analytics: [] });
+  const [analyticsHistory, setAnalyticsHistory] = useState<TimestampedAnalytics[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState("charts");
+  const metricHistory = useMetricHistory();
 
   // Poll the /api/v1/timeseries/data endpoint
   useEffect(() => {
@@ -44,6 +54,20 @@ const TimeseriesOutputPanel = () => {
         if (active) {
           setData(json);
           setError(null);
+
+          // Add one point per poll (the latest record) — mirrors how CPU/GPU accumulate
+          if (json.analytics.length > 0) {
+            const latest = json.analytics[json.analytics.length - 1];
+            const now = Date.now();
+            setAnalyticsHistory((prev) => {
+              const cutoff = now - MAX_WINDOW_MS;
+              return [...prev, {
+                timestamp: now,
+                inference_time_ms: latest.inference_time_ms,
+                end_to_end_time_ms: latest.end_to_end_time_ms,
+              }].filter((p) => p.timestamp >= cutoff);
+            });
+          }
         }
       } catch (e) {
         if (active) setError(String(e));
@@ -58,18 +82,39 @@ const TimeseriesOutputPanel = () => {
     };
   }, []);
 
-  // Chart data transforms
+  // Chart data transforms — sliding window, real timestamps
   const inferenceChart: MetricDataPoint[] = useMemo(
-    () => data.analytics.map((r, i) => ({ timestamp: Date.now() - (data.analytics.length - i) * 5000, value: r.inference_time_ms })),
-    [data.analytics],
+    () => analyticsHistory.map((r) => ({ timestamp: r.timestamp, value: r.inference_time_ms })),
+    [analyticsHistory],
   );
 
   const e2eChart: MetricDataPoint[] = useMemo(
-    () => data.analytics.map((r, i) => ({ timestamp: Date.now() - (data.analytics.length - i) * 5000, value: r.end_to_end_time_ms })),
-    [data.analytics],
+    () => analyticsHistory.map((r) => ({ timestamp: r.timestamp, value: r.end_to_end_time_ms })),
+    [analyticsHistory],
   );
 
   const yMax = (pts: MetricDataPoint[]) => Math.ceil(Math.max(...pts.map((p) => p.value ?? 0), 1) * 1.2);
+
+  // System metrics from the metrics stream
+  const cpuChart: MetricDataPoint[] = useMemo(
+    () => metricHistory.map((p) => ({ timestamp: p.timestamp, value: p.cpu ?? 0 })),
+    [metricHistory],
+  );
+
+  const gpuChart: MetricDataPoint[] = useMemo(() => {
+    return metricHistory.map((p) => {
+      const gpuIds = Object.keys(p.gpus);
+      if (gpuIds.length === 0) return { timestamp: p.timestamp, value: 0 };
+      // Use max engine usage across all GPUs
+      const maxUsage = Math.max(
+        ...gpuIds.map((id) => {
+          const g = p.gpus[id];
+          return Math.max(g.compute ?? 0, g.render ?? 0, g.copy ?? 0, g.video ?? 0, g.videoEnhance ?? 0);
+        }),
+      );
+      return { timestamp: p.timestamp, value: maxUsage };
+    });
+  }, [metricHistory]);
 
   // Latest records for metadata JSON display
   const latestIngestion = data.ingestion[data.ingestion.length - 1];
@@ -90,12 +135,12 @@ const TimeseriesOutputPanel = () => {
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="flex flex-col min-w-0">
         <TabsList>
-          <TabsTrigger value="charts">Charts</TabsTrigger>
           <TabsTrigger value="metadata">Metadata JSON</TabsTrigger>
+          <TabsTrigger value="charts">Performance</TabsTrigger>          
         </TabsList>
 
         <TabsContent value="charts" className="space-y-4 mt-2">
-          {data.analytics.length > 0 && (
+          {analyticsHistory.length > 0 && (
             <>
               <MetricChart
                 title="Inference Time"
@@ -121,6 +166,29 @@ const TimeseriesOutputPanel = () => {
               />
             </>
           )}
+
+          <MetricChart
+            title="CPU Usage"
+            data={cpuChart}
+            dataKeys={["value"]}
+            colors={["var(--color-green-chart, #4ade80)"]}
+            unit="%"
+            yAxisDomain={[0, 100]}
+            showLegend={false}
+            labels={["CPU Usage"]}
+            maxDataPoints={MAX_DATA_POINTS}
+          />
+          <MetricChart
+            title="GPU Usage"
+            data={gpuChart}
+            dataKeys={["value"]}
+            colors={["var(--color-orange-chart, #fb923c)"]}
+            unit="%"
+            yAxisDomain={[0, 100]}
+            showLegend={false}
+            labels={["GPU Usage"]}
+            maxDataPoints={MAX_DATA_POINTS}
+          />
 
           {data.ingestion.length === 0 && data.analytics.length === 0 && (
             <p className="text-sm text-muted-foreground">Waiting for data...</p>

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/TimeseriesOutputPanel.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/TimeseriesOutputPanel.tsx
@@ -42,7 +42,6 @@ const TimeseriesOutputPanel = () => {
   const [activeTab, setActiveTab] = useState("charts");
   const metricHistory = useMetricHistory();
 
-  // Poll the /api/v1/timeseries/data endpoint
   useEffect(() => {
     let active = true;
 
@@ -55,7 +54,6 @@ const TimeseriesOutputPanel = () => {
           setData(json);
           setError(null);
 
-          // Add one point per poll (the latest record) — mirrors how CPU/GPU accumulate
           if (json.analytics.length > 0) {
             const latest = json.analytics[json.analytics.length - 1];
             const now = Date.now();
@@ -82,7 +80,6 @@ const TimeseriesOutputPanel = () => {
     };
   }, []);
 
-  // Chart data transforms — sliding window, real timestamps
   const inferenceChart: MetricDataPoint[] = useMemo(
     () => analyticsHistory.map((r) => ({ timestamp: r.timestamp, value: r.inference_time_ms })),
     [analyticsHistory],
@@ -95,7 +92,6 @@ const TimeseriesOutputPanel = () => {
 
   const yMax = (pts: MetricDataPoint[]) => Math.ceil(Math.max(...pts.map((p) => p.value ?? 0), 1) * 1.2);
 
-  // System metrics from the metrics stream
   const cpuChart: MetricDataPoint[] = useMemo(
     () => metricHistory.map((p) => ({ timestamp: p.timestamp, value: p.cpu ?? 0 })),
     [metricHistory],
@@ -105,7 +101,6 @@ const TimeseriesOutputPanel = () => {
     return metricHistory.map((p) => {
       const gpuIds = Object.keys(p.gpus);
       if (gpuIds.length === 0) return { timestamp: p.timestamp, value: 0 };
-      // Use max engine usage across all GPUs
       const maxUsage = Math.max(
         ...gpuIds.map((id) => {
           const g = p.gpus[id];
@@ -116,7 +111,6 @@ const TimeseriesOutputPanel = () => {
     });
   }, [metricHistory]);
 
-  // Latest records for metadata JSON display
   const latestIngestion = data.ingestion[data.ingestion.length - 1];
   const ingestionHtml = useMemo(
     () => (latestIngestion ? highlightJson(JSON.stringify(latestIngestion, null, 2)) : ""),

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/nodes/DataSrcNode.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/nodes/DataSrcNode.tsx
@@ -11,7 +11,7 @@ type DataSrcNodeProps = {
 
 const DataSrcNode = ({ data }: DataSrcNodeProps) => (
   <PipelineNodeCard
-    title="Data Source"
+    title="Input"
     nodeType="datasrc"
     roleClasses={PIPELINE_NODE_ROLE_CLASSES.source}
     minWidthClass="min-w-[17.5rem]"

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/nodes/TsamUdfNode.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/nodes/TsamUdfNode.tsx
@@ -12,7 +12,7 @@ type TsamUdfNodeProps = {
 
 const TsamUdfNode = ({ data }: TsamUdfNodeProps) => (
   <PipelineNodeCard
-    title="Anomaly Detection UDF"
+    title="Anomaly Detection"
     nodeType="tsam-udf"
     roleClasses={PIPELINE_NODE_ROLE_CLASSES.aiDetect}
     minWidthClass="min-w-[20rem]"

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/Pipelines.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/Pipelines.tsx
@@ -161,6 +161,7 @@ export const Pipelines = () => {
   );
   const [showDetailsPanel, setShowDetailsPanel] = useState(false);
   const [selectedNode, setSelectedNode] = useState<ReactFlowNode | null>(null);
+  const [timeseriesStarted, setTimeseriesStarted] = useState(false);
   const nodeDetailsPanelSizeRef = useRef(24);
   const runPanelSizeRef = useRef(35);
   const detailsPanelRef = useRef<HTMLDivElement>(null);
@@ -267,12 +268,12 @@ export const Pipelines = () => {
   };
 
   const handleNodeSelect = (node: ReactFlowNode | null) => {
-    if (jobStatus?.state === "RUNNING") {
+    if (jobStatus?.state === "RUNNING" && !data?.tags?.includes("Time Series")) {
       return;
     }
 
     setSelectedNode(node);
-    setShowDetailsPanel(!!node);
+    setShowDetailsPanel(!!node || timeseriesStarted);
 
     if (node) {
       setCompletedVideoPath(null);
@@ -301,6 +302,7 @@ export const Pipelines = () => {
 
     // Time Series pipelines don't use GStreamer — just show the output panel
     if (data?.tags?.includes("Time Series")) {
+      setTimeseriesStarted(true);
       setShowDetailsPanel(true);
       setSelectedNode(null);
       return;
@@ -463,11 +465,13 @@ export const Pipelines = () => {
   if (isSuccess && data) {
     const isTimeSeriesPipeline = data.tags?.includes("Time Series") ?? false;
     const detailsPanelType: "node" | "run" | "timeseries" | null = showDetailsPanel
-      ? isTimeSeriesPipeline
-        ? "timeseries"
-        : selectedNode
-          ? "node"
-          : "run"
+      ? selectedNode
+        ? "node"
+        : isTimeSeriesPipeline && timeseriesStarted
+          ? "timeseries"
+          : isTimeSeriesPipeline
+            ? null
+            : "run"
       : null;
     const activePanelSize =
       detailsPanelType === "node"


### PR DESCRIPTION
## Changes

- Add CPU Usage and GPU Usage charts to Wind Turbine Anomaly Detection panel
- Rename "Data Source" node to "Input"
- Allow node click to show details panel in Time Series pipelines
- Show performance charts only after "Run pipeline" is clicked
- Fix chart timing: use sliding 60s window with real timestamps for inference/end-to-end charts
- Set polling interval to 1s for responsive chart updates